### PR TITLE
fix: resolve TensorFlow/Keras 3 conflict breaking Labs 2 & 3 on SageMaker Studio

### DIFF
--- a/lab2-response-level-detection.ipynb
+++ b/lab2-response-level-detection.ipynb
@@ -77,7 +77,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install -q -e ."
+    "# %pip install -q -e .\n",
+    "# %pip uninstall -y tensorflow keras tf-keras -q 2>/dev/null"
    ]
   },
   {

--- a/lab3-token-probability-level-detection.ipynb
+++ b/lab3-token-probability-level-detection.ipynb
@@ -90,7 +90,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# %pip install -q -e ."
+    "# %pip install -q -e .\n",
+    "# %pip uninstall -y tensorflow keras tf-keras -q 2>/dev/null"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "sentence-transformers>=5.1.0",
     "strands-agents-tools>=0.2.8",
     "strands-agents[otel,sagemaker]>=1.10",
-    "transformers>=4.56.1",
+    "transformers[torch]>=4.56.1",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
Fixes #17

## Problem

Labs 2 and 3 fail on import with:

    ValueError: Your currently installed version of Keras is Keras 3,
    but this is not yet supported in Transformers.

The SageMaker Studio base conda image ships with keras==3.14.1 and
tensorflow==2.19.1 pre-installed, but no tf-keras compatibility layer.
When transformers or sentence-transformers is imported, it detects TF,
tries to load tf_keras, and crashes.

## Fix

1. `pyproject.toml`: Use `transformers[torch]` extra to signal PyTorch-only usage
2. Labs 2 & 3: Add `pip uninstall -y tensorflow keras tf-keras` to the
   existing install cells to remove conflicting packages from the base image

## Testing

Verified on a fresh SageMaker Studio environment:
- `from transformers import pipeline` succeeds without os.environ workarounds
- `from sentence_transformers import SentenceTransformer` succeeds
- `is_tf_available()` returns False
- `is_torch_available()` returns True